### PR TITLE
convert == to ===

### DIFF
--- a/src/CurlPlusClient.php
+++ b/src/CurlPlusClient.php
@@ -320,7 +320,7 @@ class CurlPlusClient
             $this->setCurlOpt(CURLINFO_HEADER_OUT, true);
 
         // Output response header into body if body is being returned to memory, rather than output buffer
-        if (!$this->curlOptSet(CURLOPT_HEADER) && $this->getCurlOptValue(CURLOPT_RETURNTRANSFER) == true)
+        if (!$this->curlOptSet(CURLOPT_HEADER) && $this->getCurlOptValue(CURLOPT_RETURNTRANSFER) === true)
             $this->setCurlOpt(CURLOPT_HEADER, true);
 
         // Set the CURLOPTS

--- a/src/Response/CurlPlusResponse.php
+++ b/src/Response/CurlPlusResponse.php
@@ -32,7 +32,7 @@ class CurlPlusResponse implements ICurlPlusResponse
     {
         if (is_string($response) &&
             isset($curlOpts[CURLOPT_HEADER]) &&
-            $curlOpts[CURLOPT_HEADER] == true &&
+            $curlOpts[CURLOPT_HEADER] === true &&
             stripos($response, 'http/') === 0 &&
             ($pos = strpos($response, "\r\n\r\n")) !== false)
         {


### PR DESCRIPTION
With booleans, only strict comparison (with === operator) should be used to lower bug risks and to improve performances.
